### PR TITLE
Create docker-php-memlimit.ini

### DIFF
--- a/root/usr/local/etc/php/conf.d/docker-php-memlimit.ini
+++ b/root/usr/local/etc/php/conf.d/docker-php-memlimit.ini
@@ -1,0 +1,1 @@
+memory_limit = 512M


### PR DESCRIPTION
Set PHP memory limit to the recommended value of 512 MB using a custom configuration
see https://github.com/nextcloud/docker/issues/447